### PR TITLE
Exclude `errors` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .DS_Store
-errors/*
+errors/


### PR DESCRIPTION
Currently what excluded are the files inside, but not the `error` folder itself.